### PR TITLE
Injectable naming strategy and extentable services.

### DIFF
--- a/src/Adapter/DoctrineAdapter.php
+++ b/src/Adapter/DoctrineAdapter.php
@@ -12,6 +12,7 @@
 namespace Csa\GuzzleHttp\Middleware\Cache\Adapter;
 
 use Csa\GuzzleHttp\Middleware\Cache\NamingStrategy\HashNamingStrategy;
+use Csa\GuzzleHttp\Middleware\Cache\NamingStrategy\NamingStrategyInterface;
 use Doctrine\Common\Cache\Cache;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
@@ -23,10 +24,15 @@ class DoctrineAdapter implements StorageAdapterInterface
     private $namingStrategy;
     private $ttl;
 
-    public function __construct(Cache $cache, $ttl = 0)
+    /**
+     * @param Cache $cache
+     * @param int $ttl
+     * @param NamingStrategyInterface|null $namingStrategy
+     */
+    public function __construct(Cache $cache, $ttl = 0, NamingStrategyInterface $namingStrategy = null)
     {
         $this->cache = $cache;
-        $this->namingStrategy = new HashNamingStrategy();
+        $this->namingStrategy = $namingStrategy ?: new HashNamingStrategy();
         $this->ttl = $ttl;
     }
 
@@ -52,7 +58,7 @@ class DoctrineAdapter implements StorageAdapterInterface
         $data = [
             'status' => $response->getStatusCode(),
             'headers' => $response->getHeaders(),
-            'body' => (string) $response->getBody(),
+            'body' => (string)$response->getBody(),
             'version' => $response->getProtocolVersion(),
             'reason' => $response->getReasonPhrase(),
         ];

--- a/src/Adapter/MockStorageAdapter.php
+++ b/src/Adapter/MockStorageAdapter.php
@@ -62,8 +62,6 @@ class MockStorageAdapter implements StorageAdapterInterface
         foreach ($this->namingStrategies as $strategy) {
             if (file_exists($filename = $this->getFilename($strategy->filename($request)))) {
                 return Psr7\parse_response(file_get_contents($filename));
-            } else {
-                var_dump($filename);
             }
         }
     }

--- a/src/Adapter/MockStorageAdapter.php
+++ b/src/Adapter/MockStorageAdapter.php
@@ -33,16 +33,21 @@ class MockStorageAdapter implements StorageAdapterInterface
 
     /**
      * @param string $storagePath
-     * @param array  $requestHeadersBlacklist
-     * @param array  $responseHeadersBlacklist
+     * @param array $requestHeadersBlacklist
+     * @param array $responseHeadersBlacklist
+     * @param NamingStrategyInterface|null $namingStrategy
      */
-    public function __construct($storagePath, array $requestHeadersBlacklist = [], array $responseHeadersBlacklist = [])
+    public function __construct($storagePath, array $requestHeadersBlacklist = [], array $responseHeadersBlacklist = [], NamingStrategyInterface $namingStrategy = null)
     {
         $this->storagePath = $storagePath;
 
-        $this->namingStrategies[] = new SubfolderNamingStrategy($requestHeadersBlacklist);
-        $this->namingStrategies[] = new LegacyNamingStrategy(true, $requestHeadersBlacklist);
-        $this->namingStrategies[] = new LegacyNamingStrategy(false, $requestHeadersBlacklist);
+        if ($namingStrategy) {
+            $this->namingStrategies[] = $namingStrategy;
+        } else {
+            $this->namingStrategies[] = new SubfolderNamingStrategy($requestHeadersBlacklist);
+            $this->namingStrategies[] = new LegacyNamingStrategy(true, $requestHeadersBlacklist);
+            $this->namingStrategies[] = new LegacyNamingStrategy(false, $requestHeadersBlacklist);
+        }
 
         if (!empty($responseHeadersBlacklist)) {
             $this->responseHeadersBlacklist = $responseHeadersBlacklist;
@@ -57,6 +62,8 @@ class MockStorageAdapter implements StorageAdapterInterface
         foreach ($this->namingStrategies as $strategy) {
             if (file_exists($filename = $this->getFilename($strategy->filename($request)))) {
                 return Psr7\parse_response(file_get_contents($filename));
+            } else {
+                var_dump($filename);
             }
         }
     }

--- a/src/Adapter/PsrAdapter.php
+++ b/src/Adapter/PsrAdapter.php
@@ -12,6 +12,7 @@
 namespace Csa\GuzzleHttp\Middleware\Cache\Adapter;
 
 use Csa\GuzzleHttp\Middleware\Cache\NamingStrategy\HashNamingStrategy;
+use Csa\GuzzleHttp\Middleware\Cache\NamingStrategy\NamingStrategyInterface;
 use GuzzleHttp\Psr7\Response;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
@@ -23,10 +24,15 @@ class PsrAdapter implements StorageAdapterInterface
     private $namingStrategy;
     private $ttl;
 
-    public function __construct(CacheItemPoolInterface $cache, $ttl = 0)
+    /**
+     * @param CacheItemPoolInterface $cache
+     * @param int $ttl
+     * @param NamingStrategyInterface|null $namingStrategy
+     */
+    public function __construct(CacheItemPoolInterface $cache, $ttl = 0, NamingStrategyInterface $namingStrategy = null)
     {
         $this->cache = $cache;
-        $this->namingStrategy = new HashNamingStrategy();
+        $this->namingStrategy = $namingStrategy ?: new HashNamingStrategy();
         $this->ttl = $ttl;
     }
 

--- a/tests/Adapter/DoctrineAdapterTest.php
+++ b/tests/Adapter/DoctrineAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Csa\Tests\GuzzleHttp\Middleware\Cache\Adapter;
 
 use Csa\GuzzleHttp\Middleware\Cache\Adapter\DoctrineAdapter;
+use Csa\GuzzleHttp\Middleware\Cache\NamingStrategy\NamingStrategyInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -78,11 +79,41 @@ class DoctrineAdapterTest extends \PHPUnit_Framework_TestCase
                 10
             );
         $adapter = new $this->class($cache, 10);
-        $adapter->save($this->getRequestMock(), new Response(200, [], 'Hello World'));
+        $adapter->save($this->getRequestMock(), $this->getResponseMock());
+    }
+
+    public function testFetchWithInjectedNamingStrategy()
+    {
+        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $namingStrategy = $this->getMock(NamingStrategyInterface::class);
+        $request = $this->getRequestMock();
+        $adapter = new $this->class($cache, 0, $namingStrategy);
+
+        $namingStrategy->expects($this->once())->method('filename')->with($request);
+
+        $adapter->fetch($request);
+    }
+
+    public function testSaveWithInjectedNamingStrategy()
+    {
+        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $namingStrategy = $this->getMock(NamingStrategyInterface::class);
+        $request = $this->getRequestMock();
+        $response = $this->getResponseMock();
+        $adapter = new $this->class($cache, 0, $namingStrategy);
+
+        $namingStrategy->expects($this->once())->method('filename')->with($request);
+
+        $adapter->save($request, $response);
     }
 
     private function getRequestMock()
     {
         return new Request('GET', 'http://google.com/', ['Accept' => 'text/html']);
+    }
+
+    private function getResponseMock()
+    {
+        return new Response(200, [], 'Hello World');
     }
 }

--- a/tests/Adapter/MockStorageAdapterTest.php
+++ b/tests/Adapter/MockStorageAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Csa\Tests\GuzzleHttp\Middleware\Cache\Adapter;
 
 use Csa\GuzzleHttp\Middleware\Cache\Adapter\MockStorageAdapter;
+use Csa\GuzzleHttp\Middleware\Cache\NamingStrategy\NamingStrategyInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -94,6 +95,28 @@ class MockStorageAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(404, $response->getStatusCode());
 
         $this->assertFalse($response->hasHeader('X-Foo'));
+    }
+
+    public function testFetchWithInjectedNamingStrategy()
+    {
+        $namingStrategy = $this->getMock(NamingStrategyInterface::class);
+        $request = $this->getRequestMock();
+        $adapter = new $this->class($this->tmpDir, [], [], $namingStrategy);
+
+        $namingStrategy->expects($this->once())->method('filename')->with($request);
+
+        $adapter->fetch($request);
+    }
+
+    public function testSaveWithInjectedNamingStrategy()
+    {
+        $namingStrategy = $this->getMock(NamingStrategyInterface::class);
+        $request = $this->getRequestMock();
+        $adapter = new $this->class($this->tmpDir, [], [], $namingStrategy);
+
+        $namingStrategy->expects($this->once())->method('filename')->with($request);
+
+        $adapter->save($request, new Response());
     }
 
     private function getRequestMock()


### PR DESCRIPTION
Made the naming strategy injectable.
Changed property and method visibility from private to protected where there's a reasonable use case for extending the service.
Added request body to fingerprint hash.